### PR TITLE
memory optimizations from csv parsing point of view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 wav_audios
 target
+
+*.csv

--- a/johnny/util/util_test.go
+++ b/johnny/util/util_test.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestIsValidURL(t *testing.T) {
+
+	checkComparisons := func(t testing.TB, got, want bool) {
+        t.Helper()
+        if got != want {
+            t.Errorf("got %v want %v", got, want)
+        }
+    }
+
+    t.Run("proper http-s3 audio url", func(t *testing.T) {
+		audio_url := "https://lol.yes-much-fake.amazonaws.com/9b015b18-443c-42f6-adad-8309d9659813.flac"
+		want := true
+		got := isValidURL(audio_url)
+        checkComparisons(t, got, want)
+    })
+
+
+    t.Run("s3 bucket uri", func(t *testing.T) {
+		audio_url := "s3://skit-fake-bucket/9b015b18-443c-42f6-adad-8309d9659813.flac"
+		want := false
+		got := isValidURL(audio_url)
+        checkComparisons(t, got, want)
+    })
+
+    t.Run("s3 relative path uri", func(t *testing.T) {
+		audio_url := "/skit-fake-bucket/9b015b18-443c-42f6-adad-8309d9659813.flac"
+		want := false
+		got := isValidURL(audio_url)
+        checkComparisons(t, got, want)
+    })
+
+    t.Run("empty quote", func(t *testing.T) {
+		audio_url := ""
+		want := false
+		got := isValidURL(audio_url)
+        checkComparisons(t, got, want)
+    })
+
+
+}


### PR DESCRIPTION
prior to this,
* entire csv was parsed. 
* then `audio_url`/`s3_audio_url` column was used, by converting into a huge golang-string-slice of all the values.

now, 
* we are parsing only the `audio_url`/ `s3_audio_url` column only. not any other columns from csv.
* instead of converting the entire column into slice, we are using buffered channels to have anywhere around `max(workers*2, 100)`. so we won't have huge string arrays in memory for a huge CSVs.


additional few niceties, to check if given audio_url is legit or not etc


caveats:
* now it is not a [progressbar](https://github.com/schollz/progressbar#basic-usage) anymore, since we don't know the length of actual true audio_urls, we are using [spinner](https://github.com/schollz/progressbar#progress-bar-with-unknown-length) instead.
